### PR TITLE
Make integration less noisy

### DIFF
--- a/templates/mypy.sh.tpl
+++ b/templates/mypy.sh.tpl
@@ -5,17 +5,26 @@ set -o nounset
 set -o pipefail
 
 main() {
-  local output="{OUTPUT}"
+  local output
+  local report_file
+  local status
+  report_file="{OUTPUT}"
 
   # TODO(Jonathon): Consider UX improvements using https://mypy.readthedocs.io/en/stable/command_line.html#configuring-error-messages
 
   export MYPYPATH="$(pwd):{MYPYPATH_PATH}"
 
-  {MYPY_EXE} {VERBOSE_OPT} \
-    --bazel \
-    --package-root . \
-    --config-file {MYPY_INI_PATH} \
-    --cache-map {CACHE_MAP_TRIPLES} -- {SRCS} 2>&1 | tee "${output}"
+  set +o errexit
+  output=$({MYPY_EXE} {VERBOSE_OPT} --bazel --package-root . --config-file {MYPY_INI_PATH} --cache-map {CACHE_MAP_TRIPLES} -- {SRCS} 2>&1)
+  status=$?
+  set -o errexit
+
+  echo "${output}" > "${report_file}"
+  if [[ $status -ne 0 ]]; then
+    echo "${output}" # Show MyPy's error to end-user via Bazel's console logging
+    exit 1
+  fi
+
 }
 
 main "$@"

--- a/templates/mypy.sh.tpl
+++ b/templates/mypy.sh.tpl
@@ -11,8 +11,6 @@ main() {
 
   export MYPYPATH="$(pwd):{MYPYPATH_PATH}"
 
-  echo "MYPYPATH: ${MYPYPATH}"
-
   {MYPY_EXE} {VERBOSE_OPT} \
     --bazel \
     --package-root . \


### PR DESCRIPTION
### Description 

#### Problem

This integration can be very chatty on large Python codebases. Eg: https://buildkite.com/canva-org/canva-web-build/builds/186993#d69103ab-d923-4d84-b9d2-fe3344c3568f **(Private link)**

For every Python target, it will spit out:

```
INFO: From MyPy foo/backend/deploy/bar/bee/logging_test_dummy_out:
Success: no issues found in 63 source files
```
which can flood a build log. 

#### What this PR does

Make the integration only output logs to users on MyPy errors. 

