### PR TITLE
Allow for generated files

### DIFF
--- a/templates/mypy.sh.tpl
+++ b/templates/mypy.sh.tpl
@@ -27,7 +27,7 @@ main() {
   fi
 
   set +o errexit
-  output=$($mypy {VERBOSE_OPT} --bazel --package-root . --config-file {MYPY_INI_PATH} --cache-map {CACHE_MAP_TRIPLES} -- {SRCS} 2>&1)
+  output=$($mypy {VERBOSE_OPT} --bazel --package-root . --package-root bazel-out/k8-fastbuild/bin --config-file {MYPY_INI_PATH} --cache-map {CACHE_MAP_TRIPLES} -- {SRCS} 2>&1)
   status=$?
   set -o errexit
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -14,6 +14,18 @@ py_library(
     srcs_version = "PY3",
 )
 
+py_library(
+    name = "correct_imported_mypy_typings",
+    srcs = [":correct_generated_mypy_typings", "correct_imported_mypy_typings.py"],
+    srcs_version = "PY3",
+)
+
+py_library(
+    name = "broken_imported_mypy_typings",
+    srcs = [":broken_generated_mypy_typings", "broken_imported_mypy_typings.py"],
+    srcs_version = "PY3",
+)
+
 mypy_test(
     name = "correct_mypy_test",
     deps = [":correct_mypy_typings"],
@@ -25,5 +37,37 @@ mypy_test(
 )
 
 mypy_test(
+    name = "correct_imported_mypy_test",
+    deps = [":correct_imported_mypy_typings"],
+)
+
+mypy_test(
+    name = "broken_imported_mypy_test",
+    deps = [":broken_imported_mypy_typings"],
+)
+
+mypy_test(
     name = "empty_mypy_test",
+)
+
+genrule(
+    name = "correct_generated_mypy_typings",
+    outs = ["correct_generated.py"],
+    local = True,
+    cmd =
+        ("echo -e '" +
+         "from typing import Callable\n\n" +
+         "def thrice(i: int, next_: Callable[[int], int]) -> int:\n" +
+         "   return next_(next_(next_(i)))\n' > $@"),
+)
+
+genrule(
+    name = "broken_generated_mypy_typings",
+    outs = ["broken_generated.py"],
+    local = True,
+    cmd =
+        ("echo -e '" +
+         "from typing import Callable\n\n" +
+         "def thrice(i: int, next_: Callable[[int], int]) -> str:\n" +
+         "   return next_(next_(next_(i)))\n' > $@"),
 )

--- a/test/broken_imported_mypy_typings.py
+++ b/test/broken_imported_mypy_typings.py
@@ -1,0 +1,8 @@
+from test.broken_generated import thrice
+
+
+def add(i: int) -> int:
+    return i + 1
+
+
+print(thrice(3, add))

--- a/test/correct_imported_mypy_typings.py
+++ b/test/correct_imported_mypy_typings.py
@@ -1,0 +1,8 @@
+from test.correct_generated import thrice
+
+
+def add(i: int) -> int:
+    return i + 1
+
+
+print(thrice(3, add))

--- a/test/shell/test_mypy.sh
+++ b/test/shell/test_mypy.sh
@@ -20,6 +20,22 @@ test_fails_on_broken_mypy_test() {
   action_should_fail test //test:broken_mypy_test
 }
 
+test_ok_on_valid_imported_mypy_typings() {
+  action_should_succeed build --verbose_failures --aspects //:mypy.bzl%mypy_aspect --output_groups=mypy //test:correct_imported_mypy_typings
+}
+
+test_fails_on_broken_imported_mypy_typings() {
+  action_should_fail build --verbose_failures --aspects //:mypy.bzl%mypy_aspect --output_groups=mypy //test:broken_imported_mypy_typings
+}
+
+test_ok_on_valid_imported_mypy_test() {
+  action_should_succeed test //test:correct_imported_mypy_test
+}
+
+test_fails_on_broken_imported_mypy_test() {
+  action_should_fail test //test:broken_imported_mypy_test
+}
+
 test_fails_on_empty_mypy_test() {
   action_should_fail test //test:empty_mypy_test
 }
@@ -28,4 +44,10 @@ $runner test_ok_on_valid_mypy_typings
 $runner test_fails_on_broken_mypy_typings
 $runner test_ok_on_valid_mypy_test
 $runner test_fails_on_broken_mypy_test
+
+$runner test_ok_on_valid_imported_mypy_typings
+$runner test_fails_on_broken_imported_mypy_typings
+$runner test_ok_on_valid_imported_mypy_test
+$runner test_fails_on_broken_imported_mypy_test
+
 $runner test_fails_on_empty_mypy_test


### PR DESCRIPTION
Sorry I'm back

Allows for generated files to be checked by mypy, and for external generated files to be ignored.

I've had this patch since my last PR, but only just got round to writing some tests. This might sound super edge-case and useless, but arose from me implementing this project with protobuf

If for some reason, a generated python file `is` meant to be explicitly checked, then we handle that case too.