### PR TITLE
Derive the --package-root options.

### DIFF
--- a/mypy.bzl
+++ b/mypy.bzl
@@ -92,9 +92,6 @@ def _mypy_rule_impl(ctx, is_aspect = False, exe = None, out_path = None):
     transitive_srcs_depsets = []
     stub_files = []
 
-    if not hasattr(base_rule.attr, "srcs"):
-        return None
-
     direct_src_root_paths = sets.to_list(
         sets.make([f.root.path for f in direct_src_files]),
     )

--- a/templates/mypy.sh.tpl
+++ b/templates/mypy.sh.tpl
@@ -27,7 +27,7 @@ main() {
   fi
 
   set +o errexit
-  output=$($mypy {VERBOSE_OPT} --bazel --package-root . --config-file {MYPY_INI_PATH} --cache-map {CACHE_MAP_TRIPLES} -- {SRCS} 2>&1)
+  output=$($mypy {VERBOSE_OPT} --bazel {PACKAGE_ROOTS} --config-file {MYPY_INI_PATH} --cache-map {CACHE_MAP_TRIPLES} -- {SRCS} 2>&1)
   status=$?
   set -o errexit
 


### PR DESCRIPTION
Pulls across some of @josh-newman's changes from https://github.com/thundergolfer/bazel-mypy-integration/pull/12. Also should address #15 

Fixes the following error message: `darwin-fastbuild is not a valid Python package name` which occurs when included generated sources (eg. protobuf) in a `py_` target.

----

cc @dmadisetti 
