### PR TITLE
Pass python_interpreter_path through

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,13 @@ mypy_configuration("//tools/typing:mypy.ini")
 
 load("@mypy_integration//repositories:deps.bzl", mypy_integration_deps = "deps")
 
-mypy_integration_deps("//tools/typing:mypy_version.txt")
+mypy_integration_deps(
+    mypy_requirements_file="//tools/typing:mypy_version.txt",
+)
 ```
+
+_Note_ that by default `mypy_integration_deps` will default to passing `"python3"` as the interpreter used at install,
+but this can be overridden by setting `python_interpreter` or `python_interpreter_target` (but not both).
 
 **3. Finally, if using the Bazel Aspect, add the following to your `.bazelrc` so that MyPy checking is run whenever
 Python code is built:**

--- a/repositories/deps.bzl
+++ b/repositories/deps.bzl
@@ -6,7 +6,7 @@ repository.
 
 load(":py_repositories.bzl", "py_deps")
 
-def deps(mypy_requirements_file):
+def deps(mypy_requirements_file, python_interpreter_target=None):
     """Pull in external dependencies needed by rules in this repo.
     Pull in all dependencies needed to run rules in this
     repository.
@@ -15,4 +15,4 @@ def deps(mypy_requirements_file):
     'repositories' in //repositories:repositories.bzl have been imported
     already.
     """
-    py_deps(mypy_requirements_file)
+    py_deps(mypy_requirements_file, python_interpreter_target)

--- a/repositories/deps.bzl
+++ b/repositories/deps.bzl
@@ -6,7 +6,7 @@ repository.
 
 load(":py_repositories.bzl", "py_deps")
 
-def deps(mypy_requirements_file, python_interpreter_target=None):
+def deps(mypy_requirements_file, python_interpreter=None, python_interpreter_target=None):
     """Pull in external dependencies needed by rules in this repo.
     Pull in all dependencies needed to run rules in this
     repository.
@@ -15,4 +15,4 @@ def deps(mypy_requirements_file, python_interpreter_target=None):
     'repositories' in //repositories:repositories.bzl have been imported
     already.
     """
-    py_deps(mypy_requirements_file, python_interpreter_target)
+    py_deps(mypy_requirements_file, python_interpreter, python_interpreter_target)

--- a/repositories/py_repositories.bzl
+++ b/repositories/py_repositories.bzl
@@ -5,7 +5,7 @@ Provides functions to pull the external Mypy package dependency.
 
 load("@rules_python//python:pip.bzl", "pip_install")
 
-def py_deps(mypy_requirements_file, python_interpreter_target):
+def py_deps(mypy_requirements_file, python_interpreter, python_interpreter_target):
     """Pull in external Python packages needed by py binaries in this repo.
     Pull in all dependencies needed to build the Py binaries in this
     repository. This function assumes the repositories imported by the macro
@@ -18,6 +18,6 @@ def py_deps(mypy_requirements_file, python_interpreter_target):
         pip_install(
             name = external_repo_name,
             requirements = mypy_requirements_file,
-            python_interpreter = "python3",  # mypy requires Python3
+            python_interpreter = python_interpreter or "python3",  # mypy requires Python3
             python_interpreter_target = python_interpreter_target,
         )

--- a/repositories/py_repositories.bzl
+++ b/repositories/py_repositories.bzl
@@ -5,7 +5,7 @@ Provides functions to pull the external Mypy package dependency.
 
 load("@rules_python//python:pip.bzl", "pip_install")
 
-def py_deps(mypy_requirements_file):
+def py_deps(mypy_requirements_file, python_interpreter_target):
     """Pull in external Python packages needed by py binaries in this repo.
     Pull in all dependencies needed to build the Py binaries in this
     repository. This function assumes the repositories imported by the macro
@@ -19,4 +19,5 @@ def py_deps(mypy_requirements_file):
             name = external_repo_name,
             requirements = mypy_requirements_file,
             python_interpreter = "python3",  # mypy requires Python3
+            python_interpreter_target = python_interpreter_target,
         )


### PR DESCRIPTION
Pass `python_interpreter_path` through from `WORKSPACE` repo_rule invocation to eventual pip_install execution. 

An attempt to address https://github.com/thundergolfer/bazel-mypy-integration/issues/22