### PR TITLE
Remove transitive dependencies for mypy.

### DIFF
--- a/mypy/BUILD
+++ b/mypy/BUILD
@@ -8,10 +8,6 @@ py_binary(
     visibility = ["//visibility:public"],
     deps = [
         requirement("mypy"),
-        # Transitive deps determined by looking at: https://github.com/python/mypy/blob/master/mypy-requirements.txt
-        requirement("typing_extensions"),
-        requirement("mypy_extensions"),
-        requirement("typed_ast"),
     ],
 )
 


### PR DESCRIPTION
These dependencies are now automatically pulled in by pip, no need to explicitly provide them. Good thing too, since newer versions of mypy don't use these.