### PR TITLE
report stdout error info in failed tests, if it exists

### DIFF
--- a/test/shell/test_helper.sh
+++ b/test/shell/test_helper.sh
@@ -7,12 +7,16 @@ action_should_succeed() {
   # runs the tests locally
   set +e
   TEST_ARG=$@
-  DUMMY=$(bazel $TEST_ARG)
+  OUTPUT=$(bazel $TEST_ARG)
   RESPONSE_CODE=$?
   if [ $RESPONSE_CODE -eq 0 ]; then
     exit 0
   else
-        echo -e "${RED} \"bazel $TEST_ARG\" should have passed but failed. $NC"
+    # Bazel may report useful error information to stdout.
+    if [[ -n $OUTPUT ]]; then
+        echo -e "$OUTPUT"
+    fi
+    echo -e "${RED} \"bazel $TEST_ARG\" should have passed but failed. $NC"
     exit -1
   fi
 }
@@ -21,7 +25,7 @@ action_should_fail() {
   # runs the tests locally
   set +e
   TEST_ARG=$@
-  DUMMY=$(bazel $TEST_ARG)
+  OUTPUT=$(bazel $TEST_ARG)
   RESPONSE_CODE=$?
   if [ $RESPONSE_CODE -eq 0 ]; then
     echo -e "${RED} \"bazel $TEST_ARG\" should have failed but passed. $NC"

--- a/test/shell/test_mypy.sh
+++ b/test/shell/test_mypy.sh
@@ -11,6 +11,12 @@ source "${dir}"/test_helper.sh
 
 runner=$(get_test_runner "${1:-local}")
 
+# Obviously doesn't test the integration's functionality, just the basics of repo's Bazel
+# workspace setup, a prerequisite to testing the integration's functionality.
+test_ok_running_bazel_version() {
+  action_should_succeed version
+}
+
 test_ok_on_valid_imported_mypy_typings() {
   action_should_succeed build --verbose_failures --aspects //:mypy.bzl%mypy_aspect --output_groups=mypy //test:correct_imported_mypy_typings
 }
@@ -57,6 +63,7 @@ test_fails_on_empty_mypy_test() {
 }
 
 main() {
+  $runner test_ok_running_bazel_version
   $runner test_ok_on_valid_mypy_typings
   $runner test_ok_for_package_roots_regression
   $runner test_ok_on_valid_imported_mypy_typings


### PR DESCRIPTION
https://github.com/thundergolfer/bazel-mypy-integration/pull/50 showed up that sometimes the test runner system doesn't report any failure logging. 

Using `set -x` I was able to discern that #50's build issue was a `.bazelversion` mismatch, and that the test system could report that info if `stdout` was logged on error. 